### PR TITLE
fix images not showing in ghostty term

### DIFF
--- a/nekoget
+++ b/nekoget
@@ -228,10 +228,7 @@ def glob_open(image_url, scale_factor=1.0):
         if img_attr[0] == 1:
             print(f"{Style.BRIGHT}{Fore.RED}error{Style.RESET_ALL}{Fore.RESET}: failed to get image with status {img_attr[1]}")
         else:
-            if term and "kitty" in term:
-                run(["kitten", "icat", "--align", "left", str(img_attr[1])])
-            else:
-                run(["img2sixel", str(img_attr[1])])
+            run(["kitten", "icat", "--align", "left", str(img_attr[1])])
     else:
         img_attr = get_img(image_url, scale_factor)
         if img_attr[0] == 1:


### PR DESCRIPTION
since the old code literally just checked if nekoget was running inside kitty to display images, other terminals were forced to use `img2sixels` where in most cases, the image would be much lower quality or not even appear in the terminal at all (talking about ghostty here)

since most modern terminals can simply run `kitten icat path/to/image` and display the image propely, it's no use to just make a check if kitty terminal is being used to run the program